### PR TITLE
Fill out `ParticleSystem` a little

### DIFF
--- a/code/GameEngine/Components/Effects/ParticleSystem.cs
+++ b/code/GameEngine/Components/Effects/ParticleSystem.cs
@@ -107,6 +107,14 @@ public class ParticleSystem : BaseComponent, BaseComponent.ExecuteInEditor
 		_sceneObject?.SetControlPoint( i, rotation );
 	}
 
+	public Vector3 GetControlPointPosition( int i )
+	{
+		if ( _sceneObject is null )
+			return Vector3.Zero;
+		
+		return _sceneObject.GetControlPointPosition( i );
+	}
+
 	public override void Update()
 	{
 		if ( !_sceneObject.IsValid() )

--- a/code/GameEngine/Components/Effects/ParticleSystem.cs
+++ b/code/GameEngine/Components/Effects/ParticleSystem.cs
@@ -8,11 +8,30 @@ using Sandbox.Diagnostics;
 public class ParticleSystem : BaseComponent, BaseComponent.ExecuteInEditor
 {
 	Sandbox.ParticleSystem _particles;
-
+	
 	[Property] public bool Looped { get; set; } = false;
 
 	[Range( 0, 2.0f )]
 	[Property] public float PlaybackSpeed { get; set; } = 1.0f;
+
+	private bool emissionStopped;
+	
+	/// <summary>
+	/// Turn on or off particle emission.
+	/// Useful for particles with intermittent or permanent durations.
+	/// </summary>
+	[Property]
+	public bool EmissionStopped
+	{
+		get => emissionStopped;
+		set
+		{
+			emissionStopped = value;
+			
+			if (_sceneObject is not null)
+				_sceneObject.EmissionStopped = value;
+		}
+	}
 
 	[Property] public Sandbox.ParticleSystem Particles 
 	{
@@ -26,9 +45,9 @@ public class ParticleSystem : BaseComponent, BaseComponent.ExecuteInEditor
 		}
 	}
 
+	[Property] public GameObject ControlPoint0 { get; set; }
 	[Property] public GameObject ControlPoint1 { get; set; }
 	[Property] public GameObject ControlPoint2 { get; set; }
-	[Property] public GameObject ControlPoint3 { get; set; }
 
 	SceneParticles _sceneObject;
 	public SceneParticles SceneObject => _sceneObject;
@@ -60,6 +79,32 @@ public class ParticleSystem : BaseComponent, BaseComponent.ExecuteInEditor
 
 		_sceneObject = new SceneParticles( Scene.SceneWorld, _particles );
 		_sceneObject.Transform = Transform.World;
+		_sceneObject.EmissionStopped = emissionStopped;
+	}
+
+	public void PlayEffect()
+	{
+		RecreateSceneObject();
+	}
+
+	public void Set( int i, float value )
+	{
+		_sceneObject?.SetControlPoint( i, value );
+	}
+	
+	public void Set( int i, Vector3 position )
+	{
+		_sceneObject?.SetControlPoint( i, position );
+	}
+	
+	public void Set( int i, Transform transform )
+	{
+		_sceneObject?.SetControlPoint( i, transform );
+	}
+	
+	public void Set( int i, Rotation rotation )
+	{
+		_sceneObject?.SetControlPoint( i, rotation );
 	}
 
 	public override void Update()
@@ -74,13 +119,13 @@ public class ParticleSystem : BaseComponent, BaseComponent.ExecuteInEditor
 			if ( !_sceneObject.IsValid() )
 				return;
 		}
-
-		_sceneObject.SetControlPoint( 0, ControlPoint1.IsValid() ? ControlPoint1.Transform.World : Transform.World );
-		_sceneObject.SetControlPoint( 1, ControlPoint2.IsValid() ? ControlPoint2.Transform.World : Transform.World );
-		_sceneObject.SetControlPoint( 2, ControlPoint3.IsValid() ? ControlPoint3.Transform.World : Transform.World );
-
+		
+		_sceneObject.SetControlPoint( 0, ControlPoint0.IsValid() ? ControlPoint0.Transform.World : Transform.World );
+		_sceneObject.SetControlPoint( 1, ControlPoint1.IsValid() ? ControlPoint1.Transform.World : Transform.World );
+		_sceneObject.SetControlPoint( 2, ControlPoint2.IsValid() ? ControlPoint2.Transform.World : Transform.World );
+		
 		_sceneObject.Simulate( Time.Delta * PlaybackSpeed );
-
+		
 		if ( _sceneObject.Finished )
 		{
 			_sceneObject?.Delete();


### PR DESCRIPTION
- Added a property for the `EmissionStopped` property on `SceneParticles`
- Added setters for control points and a get method for control point positions.
- fixed names for the Control Point properties being off by 1 (e.g. ControlPoint1 was setting control point 0)
- Added a `PlayEffect` method that just recreates the scene object, as otherwise you need to call OnDisabled() then OnEnabled() to achieve the same effect.