### PR TITLE
Copy Component/Paste Values/Paste As New

### DIFF
--- a/code/Editor/GameObjectInspector/GameObjectInspector.cs
+++ b/code/Editor/GameObjectInspector/GameObjectInspector.cs
@@ -223,8 +223,8 @@ public class ComponentList : Widget
 
 			var component = target.GameObject.AddComponent( componentType );
 			component.DeserializeImmediately( jso );
-			
-			SceneEditorSession.Active.FullUndoSnapshot( "Pasted Component As New" );
+
+			SceneEditorSession.Active.Scene.EditLog( "Pasted Component As New", target );
 		}
 		catch
 		{
@@ -241,7 +241,7 @@ public class ComponentList : Widget
 			if ( JsonNode.Parse( text ) is JsonObject jso )
 			{
 				target.Deserialize( jso );
-				SceneEditorSession.Active.FullUndoSnapshot( "Pasted Component Values" );
+				SceneEditorSession.Active.Scene.EditLog( "Pasted Component Values", target );
 			}
 		}
 		catch

--- a/code/Editor/GameObjectInspector/GameObjectInspector.cs
+++ b/code/Editor/GameObjectInspector/GameObjectInspector.cs
@@ -223,6 +223,8 @@ public class ComponentList : Widget
 
 			var component = target.GameObject.AddComponent( componentType );
 			component.DeserializeImmediately( jso );
+			
+			SceneEditorSession.Active.FullUndoSnapshot( "Pasted Component As New" );
 		}
 		catch
 		{
@@ -239,6 +241,7 @@ public class ComponentList : Widget
 			if ( JsonNode.Parse( text ) is JsonObject jso )
 			{
 				target.Deserialize( jso );
+				SceneEditorSession.Active.FullUndoSnapshot( "Pasted Component Values" );
 			}
 		}
 		catch

--- a/code/GameEngine/Components/BaseComponent.Serialize.cs
+++ b/code/GameEngine/Components/BaseComponent.Serialize.cs
@@ -87,6 +87,16 @@ public abstract partial class BaseComponent
 		Enabled = (bool)(node["__enabled"] ?? true);
 	}
 
+	/// <summary>
+	/// Deserialize this component as per <see cref="Deserialize"/> but update <see cref="GameObject"/> and <see cref="BaseComponent"/> property
+	/// references immediately instead of having them deferred.
+	/// </summary>
+	public void DeserializeImmediately( JsonObject node )
+	{
+		Deserialize( node );
+		PostDeserialize();
+	}
+
 	private void DeserializeProperty( PropertyDescription prop, JsonNode node )
 	{
 		if ( prop.PropertyType == typeof( GameObject ) )


### PR DESCRIPTION
The reason this is a PR is because I just wanted to start a discussion around copy and pasting stuff like this.

At the moment if you have something in your clipboard that isn't valid JSON and you try to do something like `Scene->Paste As Child` you'll get an exception thrown.

And, in the case of copy and pasting components you might only want to show stuff like `Paste Values` or `Paste As New` when the contents of the clipboard is valid for that...

Should we have some utility methods in `Clipboard` or somewhere else where you could do something like:

`Clipboard.Copy( string someCopyType, string data )`
`bool Clipboard.Contains( string someCopyType)`

I would think in these cases `Clipboard.Paste( string someCopyType )` would just return the data as expected or an empty string/null if it doesn't contain that type.

An example in this case would be:

```csharp
  var result = component.Serialize();
  EditorUtility.Clipboard.Copy( "component", result.ToString() );
```

```csharp
if ( EditorUtility.Clipboard.Contains( "component" ) )
{
  menu.AddOption( "Paste Values", action: () => PasteComponentValues( component ) );
  menu.AddOption( "Paste As New", action: () => PasteComponentAsNew( component ) );
}
```

Just some thoughts... maybe this is bollocks and we should just wrap everything in a try/catch.