### PR TITLE
Add GameObject.GetOrAddComponent<T>

### DIFF
--- a/code/GameEngine/GameObject/GameObject.Component.cs
+++ b/code/GameEngine/GameObject/GameObject.Component.cs
@@ -73,6 +73,23 @@ public partial class GameObject
 	}
 
 	/// <summary>
+	/// Get the first matching component on this game object. 
+	/// If no match is found, a new component is added and returned.
+	/// </summary>
+	/// <param name="enabledOnly">
+	/// If true, a new component will be created when the only matching component is disabled.
+	/// If false, the first matching component will be returned regardless of its enabled state.
+	/// </param>
+	public T GetOrAddComponent<T>( bool enabledOnly = true ) where T : BaseComponent, new()
+	{
+		if ( !TryGetComponent( out T component, enabledOnly, false ) )
+		{
+			component = AddComponent<T>();
+		}
+		return component;
+	}
+
+	/// <summary>
 	/// Find component on this gameobject, or its parents
 	/// </summary>
 	public T GetComponentInParent<T>( bool enabledOnly = true, bool andSelf = false )

--- a/code/GameEngine/GameObject/GameObject.Component.cs
+++ b/code/GameEngine/GameObject/GameObject.Component.cs
@@ -73,18 +73,14 @@ public partial class GameObject
 	}
 
 	/// <summary>
-	/// Get the first matching component on this game object. 
-	/// If no match is found, a new component is added and returned.
+	/// Get the first matching component on this game object, including components
+	/// that are disabled. If no such component is found, add and return a new one.
 	/// </summary>
-	/// <param name="enabledOnly">
-	/// If true, a new component will be created when the only matching component is disabled.
-	/// If false, the first matching component will be returned regardless of its enabled state.
-	/// </param>
-	public T GetOrAddComponent<T>( bool enabledOnly = true ) where T : BaseComponent, new()
+	public T GetOrAddComponent<T>( bool startEnabled = true ) where T : BaseComponent, new()
 	{
-		if ( !TryGetComponent( out T component, enabledOnly, false ) )
+		if ( !TryGetComponent( out T component, false ) )
 		{
-			component = AddComponent<T>();
+			component = AddComponent<T>( startEnabled );
 		}
 		return component;
 	}


### PR DESCRIPTION
This method is similar to `EntityComponentSystem.GetOrCreate<T>`, which also makes the assumption that the caller does not want to create a new component if a disabled instance of the same component already exists.